### PR TITLE
Replace properties with `async` methods

### DIFF
--- a/TerminateServiceOnCondition/IResourceChecksum.cs
+++ b/TerminateServiceOnCondition/IResourceChecksum.cs
@@ -4,8 +4,8 @@
   {
     string Resource { get; }
 
-    Lazy<string?> Checksum { get; }
-    
-    bool Exists { get; }
+    Task<string?> GetChecksum(CancellationToken cancellationToken);
+
+    Task<bool> Exists(CancellationToken cancellationToken);
   }
 }

--- a/TerminateServiceOnCondition/ResourceWatcher.cs
+++ b/TerminateServiceOnCondition/ResourceWatcher.cs
@@ -7,7 +7,8 @@ internal class ResourceWatcher : BackgroundService
   private readonly Func<string, IResourceChecksum> _resourceChecksumFactory;
   private readonly IHostApplicationLifetime _lifetime;
   private readonly ILogger<ResourceWatcher> _logger;
-  private readonly Dictionary<string, string?> _resources ;
+  private readonly string[] _resources ;
+  private readonly Dictionary<string, string?> _checksums = new Dictionary<string, string?>() ;
 
   #endregion
 
@@ -20,29 +21,32 @@ internal class ResourceWatcher : BackgroundService
     _resourceChecksumFactory = resourceChecksumFactory;
     _lifetime = lifetime;
     _logger = logger;
-    _resources = resources
-      .Select(r => _resourceChecksumFactory(r))
-      .ToDictionary(x => x.Resource, x => x.Checksum.Value);
+    _resources = resources.ToArray();
   }
   
   protected override async Task ExecuteAsync(CancellationToken stoppingToken)
   {
+    foreach (var resource in _resources)
+    {
+      var resourceChecksum = _resourceChecksumFactory(resource);
+      var checksum = await resourceChecksum.GetChecksum(stoppingToken);
+      _checksums.Add(resource, checksum);
+    }
+    
     while (!stoppingToken.IsCancellationRequested)
     {
       _logger.LogInformation("Checker running at: {time}", DateTime.UtcNow);
-            
-      var scanResult = _resources
-        .Select(kvp => ChecksumChanged(kvp.Key, kvp.Value))
-        .FirstOrDefault(x => x.Changed);
+      
+      var changedResource = await ScanForChangedResources(stoppingToken);
 
-      if (scanResult.Changed)
+      if (changedResource != null)
       {
-        _logger.LogInformation($"{scanResult.Resource} has changed, terminating...");
+        _logger.LogInformation($"{changedResource} has changed or is no longer available, terminating...");
         _lifetime.StopApplication();
       } 
       else
       {
-        _logger.LogInformation("No changes detected in target resources.");
+        _logger.LogInformation("No changes detected in monitored resources.");
       }
             
       await Task.Delay(1000, stoppingToken);
@@ -51,24 +55,42 @@ internal class ResourceWatcher : BackgroundService
 
   #region Internals
 
-  private (bool Changed, string Resource) ChecksumChanged(string resource, string? previousChecksum)
+  private async Task<string?> ScanForChangedResources(CancellationToken cancellationToken)
   {
-    var newResource = _resourceChecksumFactory(resource);
-    if (!newResource.Exists)
+    foreach (var (resource, checksum) in _checksums)
     {
-      // If the resource does not exist, but we have a previous checksum, it means the resource has been deleted
-      return (previousChecksum != null, resource);
-    }
+      var newResource = _resourceChecksumFactory(resource);
+      var exists = await newResource.Exists(cancellationToken);
+      if (!exists)
+      {
+        if (checksum != null)
+        {
+          return resource;
+        }
+        
+        // the resource does not exist, and it did not exist before, so we can go and check the next one
+        continue;
+      }
 
-    // If resource exists, but we have no previous checksum, it means it's a new resource
-    if (previousChecksum is null)
-    {
-      return (true, resource);
+      // If resource exists, but we have no previous checksum, it means it's a new resource:
+      // we've found a changed resource, so we can return it
+      if (checksum is null)
+      {
+        return resource;
+      }
+      
+      // In any other case, compare checksums
+      var currentChecksum = await newResource.GetChecksum(cancellationToken);
+      // if checksum is different, the resource has changed, so we can return it
+      if (currentChecksum != checksum)
+      {
+        return resource;
+      }
     }
-
-    // In any other case, compare checksums
-    return (newResource.Checksum.Value != previousChecksum, resource);  
+    
+    // No changes detected in any of the resources
+    return null;
   }
-
+  
   #endregion
 }


### PR DESCRIPTION
In order to support other types of "resources" (e.g. remote URIs), properties `Exists` and `CheckSum` in `IResourceChecksum` are replaced by `async` methods